### PR TITLE
Better time allocation implementation

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -242,7 +242,45 @@ vector<string> Executor::Execute(const string& command_str) {
     search_params_.thinking_output = true;
   } else if (cmd == "quit") {
     quit_ = true;
-  } else if (cmd == "Error" || cmd == "feature" || cmd == "level" ||
+  } else if (cmd == "level") {
+    // XBoard level command: "level MOVES BASE INC"
+    // MOVES = moves per time control (0 = all moves)
+    // BASE = base time in minutes:seconds or minutes
+    // INC = increment per move in seconds
+    if (cmd_parts.size() >= 4) {
+      try {
+        movestogo_ = StringToInt(cmd_parts.at(1));
+        
+        // Parse base time (can be "minutes" or "minutes:seconds")
+        const std::string& base_str = cmd_parts.at(2);
+        size_t colon_pos = base_str.find(':');
+        double base_minutes = 0;
+        if (colon_pos != std::string::npos) {
+          // Format: "minutes:seconds"
+          int minutes = StringToInt(base_str.substr(0, colon_pos));
+          int seconds = StringToInt(base_str.substr(colon_pos + 1));
+          base_minutes = minutes + seconds / 60.0;
+        } else {
+          // Format: "minutes"
+          base_minutes = StringToInt(base_str);
+        }
+        
+        // Convert to centiseconds and set both sides' time
+        double base_centis = base_minutes * 60 * 100;
+        time_centis_ = base_centis;
+        otime_centis_ = base_centis;
+        
+        // Parse increment in seconds, convert to centiseconds
+        double inc_seconds = std::stod(cmd_parts.at(3));
+        inc_centis_ = static_cast<int>(inc_seconds * 100);
+        
+        std::cout << "# Level set: " << movestogo_ << " moves, " 
+                  << base_minutes << " minutes, " << inc_seconds << " sec increment" << std::endl;
+      } catch (const std::exception& e) {
+        std::cout << "# Error parsing level command" << std::endl;
+      }
+    }
+  } else if (cmd == "Error" || cmd == "feature" ||
              cmd == "xboard" || cmd == "accepted" || cmd == "rejected" ||
              cmd == "?" || cmd == "protover" || cmd == "sigterm" ||
              cmd == "name" || cmd == "rating" || cmd == "computer" ||
@@ -268,35 +306,32 @@ long Executor::AllocateTime() const {
   if (think_time_centis_ > 0) {
     return think_time_centis_;
   }
-  if (time_centis_ < 500) {
-    return 1l;
-  }
-  double a, b, c, d, e;
-  if (IsStandard(variant_)) {
-    a = -1.50140990e-08;
-    b = 7.61654331e-06;
-    c = 1.86255488e-04;
-    d = -5.43305966e-01;
-    e = 9.66625927e+01;
-  } else if (IsAntichessLike(variant_)) {
-    a = 1.04978830e-06;
-    b = -3.17302622e-04;
-    c = 3.41067191e-02;
-    d = -1.57304241e+00;
-    e = 4.83298816e+01;
+  
+  // In XBoard protocol: time = engine's time, otim = opponent's time
+  double our_time_centis = time_centis_;
+  double our_inc_centis = inc_centis_;
+  
+  long calculated_time_centis = 0;
+  if (our_time_centis > 0) {
+    if (movestogo_ > 0) {
+      // If moves to go is specified, divide remaining time by moves plus buffer
+      calculated_time_centis = static_cast<long>(our_time_centis / (movestogo_ + 2) + our_inc_centis);
+    } else {
+      // Default: use 1/30 of remaining time plus increment
+      calculated_time_centis = static_cast<long>(our_time_centis / 30 + our_inc_centis);
+    }
+    
+    // Minimum 10 centis (0.1s), maximum 1/3 of remaining time for safety
+    calculated_time_centis = std::max(10l, std::min(calculated_time_centis, static_cast<long>(our_time_centis / 3)));
   } else {
-    assert(false); // unreachable
+    // Fallback if no valid time information
+    calculated_time_centis = 100l; // 1 second default
   }
-  const int movenum = main_context_->board->HalfMoveClock();
-  const double est_self_moves_remaining =
-      (std::max(a * pow(movenum, 4) + b * pow(movenum, 3) +
-                    c * pow(movenum, 2) + d * movenum + e,
-                20.0)) /
-      2;
-  const long alloc_centis =
-      static_cast<long>(time_centis_ / est_self_moves_remaining);
-  std::cout << "# Allocating time: " << alloc_centis << " centis" << std::endl;
-  return alloc_centis;
+  
+  std::cout << "# Time allocation: " << calculated_time_centis << " centis" 
+            << " (time=" << our_time_centis << ", inc=" << our_inc_centis 
+            << ", movestogo=" << movestogo_ << ")" << std::endl;
+  return calculated_time_centis;
 }
 
 void Executor::OutputFEN() const {

--- a/src/executor.h
+++ b/src/executor.h
@@ -80,6 +80,8 @@ private:
 
   double time_centis_;
   double otime_centis_;
+  int inc_centis_ = 0;        // Increment per move in centiseconds
+  int movestogo_ = 0;         // Moves to next time control
 
   // Custom board FEN which is used as initial board for all games if it is non
   // empty.


### PR DESCRIPTION
* simplified; removed the complex polynomial
* support xboard `level` cmd
* account for increment when allocating

Self play analysis shows ELO improvement at different time controls:

=======================
master = e0d6a9e065e3d29336c209c402bb29400aed986a
alt-time = this commit
=======================

=== bullet (5+0.05) ===
Score of alt-time vs master: 297 - 58 - 45  [0.799] 400 Elo difference: 239.5 +/- 38.8, LOS: 100.0 %, DrawRatio: 11.3 %

=== fast_blitz (10+0.01) ===
Score of alt-time vs master: 132 - 96 - 72  [0.560] 300 Elo difference: 41.9 +/- 34.5, LOS: 99.1 %, DrawRatio: 24.0 %

=== fast_blitz (20+0) ===
Score of alt-time vs master: 155 - 128 - 117  [0.534] 400 Elo difference: 23.5 +/- 28.7, LOS: 94.6 %, DrawRatio: 29.3 %

=== rapid (60+0.1) ===
Score of alt-time vs master: 88 - 50 - 62  [0.595] 200 Elo difference: 66.8 +/- 40.5, LOS: 99.9 %, DrawRatio: 31.0 %

=== rapid (60+0) ===
Score of alt-time vs master: 80 - 47 - 73  [0.583] 200 Elo difference: 57.9 +/- 38.7, LOS: 99.8 %, DrawRatio: 36.5 %

=== rapid (180+0) ===
Score of alt vs master: 67 - 26 - 57  [0.637] 150
Elo difference: 97.4 +/- 44.6, LOS: 100.0 %, DrawRatio: 38.0 %

=== classical (300+2) ===
Score of alt-time vs master: 23 - 5 - 13  [0.720] 41 Elo difference: 163.6 +/- 95.8, LOS: 100.0 %, DrawRatio: 31.7 %